### PR TITLE
Add `nix-watch` lock file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ By default, the workspace directories of your project and all local dependencies
 
 ## Systems
 
-MacOS is currently b0rked see [issue #4](https://github.com/Cloud-Scythe-Labs/nix-watch/issues/4) for details. Feel free to open bug fixes for any of the points listed there, or report errors in new issues using the darwin tag.
-
 - x86_64-linux
 - x86_64-darwin
 - aarch64-linux

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
             getopt
             coreutils
             ncurses
+            jq
             nixWatchBin
             ;
         };

--- a/nix-watch.nix
+++ b/nix-watch.nix
@@ -1,4 +1,4 @@
-{ stdenv, writeShellScriptBin, fswatch, getopt, coreutils, ncurses, jq }:
+{ writeShellScriptBin, fswatch, getopt, coreutils, ncurses, jq }:
 let
   fswatch' = "${fswatch}/bin/fswatch";
   getopt' = "${getopt}/bin/getopt";

--- a/nix-watch.nix
+++ b/nix-watch.nix
@@ -8,8 +8,6 @@ let
   clear = "${ncurses}/bin/clear";
   jq' = "${jq}/bin/jq";
 
-  watchRecursively = if stdenv.isDarwin then "-r" else "";
-
   nixWatchBin = writeShellScriptBin "nix-watch" ''
         # Define some colors that will help distinguish messages
         ANSI_RED='\033[0;31m'
@@ -268,10 +266,6 @@ let
         for pattern in "''${IGNORE_PATTERNS[@]}"; do
             FSWATCH_CMD+=" -e '$pattern'"
         done
-        watch_recursively=$(strip_quotes ${watchRecursively})
-        if [[ -n "$watch_recursively" ]]; then
-            FSWATCH_CMD+=" $watch_recursively"
-        fi
         FSWATCH_CMD+=" $WATCH_DIR"
         debug "fswatch command: ''${ANSI_BLUE}$FSWATCH_CMD''${ANSI_RESET}"
 

--- a/nix-watch.nix
+++ b/nix-watch.nix
@@ -201,12 +201,16 @@ let
             # Get the current modification time of the watched directory
             current_mod_time=$(${stat} -c %Y "$WATCH_DIR")
 
+            debug "Checking modification time for changes"
+            debug "Last known mod_time: ''${ANSI_BLUE}$last_mod_time''${ANSI_RESET}"
+            debug "Recieved mod_time for comparison: ''${ANSI_BLUE}$current_mod_time''${ANSI_RESET}"
             # Check if the modification time has changed
             if [ "$current_mod_time" -ne "$last_mod_time" ]; then
                 debug "Modification time has changed, updating mod_time variable..."
                 debug "Setting modification time to: ''${ANSI_BLUE}$current_mod_time''${ANSI_RESET}"
                 debug "Previously modified at: ''${ANSI_BLUE}$last_mod_time''${ANSI_RESET}"
                 last_mod_time="$current_mod_time"
+                debug "mod_time set to: ''${ANSI_BLUE}$last_mod_time''${ANSI_RESET}"
 
                 # Execute the command in the background and capture its PID
                 if [ "$NO_RESTART" == true ]; then
@@ -229,6 +233,9 @@ let
                 # Save the PID to the PID_FILE
                 ${echo} $command_pid > "$PID_FILE"
                 ${echo} -e "[''${ANSI_RED}nix-watch''${ANSI_RESET} '$WATCH_DIR']: ''${ANSI_BLUE}$COMMAND''${ANSI_RESET} ''${ANSI_GREEN}(PID: $command_pid)''${ANSI_RESET}"
+            else
+                debug "Modification time has not changed: ''${ANSI_BLUE}$last_mod_time''${ANSI_RESET}"
+                debug "Skipping..."
             fi
         }
 
@@ -243,12 +250,14 @@ let
         # Watch the directory for changes on both Linux and macOS
         nix_watch() {
             if [ "$POSTPONE" == false ]; then
+                debug "Postpone flag was unset, attempting to run command."
                 # Run the command on start, then wait so fswatch doesn't think
                 # that changes were made which causing a second run_command to trigger
                 run_command & sleep 1
             fi
 
             eval "$FSWATCH_CMD" | while read -d "" event; do
+                debug "Watcher detected changes, found event: ''${ANSI_BLUE}$event''${ANSI_RESET}"
                 run_command
             done
         }


### PR DESCRIPTION
Solves a critical problem in which the mod_time variable was being overlooked. Uses a lock file to check against for update times instead, which stores the path that changed and the modification time. Also adds a graceful shutdown which removes the PID_FILE, and removes the LOCK_FILE if DEBUG is false.

Tested on aarch64-darwin and x86_64-linux, both are working as expected.

Closes #4
Closes #7 