### PR TITLE
Add `NIX_WATCH_PRINT_BUILD_LOGS` env var

### DIFF
--- a/nix-watch.nix
+++ b/nix-watch.nix
@@ -198,7 +198,10 @@ let
             fi
             COMMAND=$(process_args "''${COMMAND[@]}")
         fi
-        if [ "$PRINT_BUILD_LOGS" == true ]; then
+        if [[ "$PRINT_BUILD_LOGS" == false && -n "$NIX_WATCH_PRINT_BUILD_LOGS" ]]; then
+            PRINT_BUILD_LOGS=$(convert_int_to_bool $NIX_WATCH_PRINT_BUILD_LOGS)
+        fi
+        if [[ "$PRINT_BUILD_LOGS" == true ]]; then
             COMMAND+=("-L")
         fi
         if [[ -n ''${SHELL_ARGS[@]} ]]; then


### PR DESCRIPTION
Ref #9 

Adds the ability to declare `NIX_WATCH_PRINT_BUILD_LOGS` environment variable.