### PR TITLE
Consolidate tests into a nix store directory

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,14 +25,7 @@
 
             buildPhase = ''
               runHook preBuild
-              ${pkgs.bats}/bin/bats ${tests.help}
-              ${pkgs.bats}/bin/bats ${tests.exec}
-              ${pkgs.bats}/bin/bats ${tests.ignore}
-              ${pkgs.bats}/bin/bats ${tests.shutdown}
-              ${pkgs.bats}/bin/bats ${tests.postpone}
-              ${pkgs.bats}/bin/bats ${tests.no-restart}
-              ${pkgs.bats}/bin/bats ${tests.shell-args}
-              ${pkgs.bats}/bin/bats ${tests.workdir}
+              ${pkgs.bats}/bin/bats ${tests.suite}
               runHook postBuild
             '';
             installPhase = ''

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,25 +1,48 @@
 { callPackage
-, writeText
+, writeTextFile
 , writeShellScriptBin
+, runCommand
 , nixWatchBin
 , bats
 , coreutils
 , gnused
 }:
+
 let
-  test_utils = callPackage ./test_utils.nix {
-    inherit writeShellScriptBin coreutils gnused;
-  };
+  test_utils = callPackage ./test_utils.nix { inherit writeShellScriptBin coreutils gnused; };
+  help = callPackage ./help.nix { inherit bats nixWatchBin writeTextFile; };
+  shutdown = callPackage ./shutdown.nix { inherit bats nixWatchBin writeTextFile; };
+  postpone = callPackage ./postpone.nix { inherit bats nixWatchBin writeTextFile; };
+  no-restart = callPackage ./no-restart.nix { inherit bats nixWatchBin writeTextFile; };
+  exec = callPackage ./exec.nix { inherit bats nixWatchBin writeTextFile test_utils; };
+  ignore = callPackage ./ignore.nix { inherit bats nixWatchBin writeTextFile test_utils; };
+  shell-args = callPackage ./shell-args.nix { inherit bats nixWatchBin writeTextFile test_utils; };
+  workdir = callPackage ./shell-args.nix { inherit bats nixWatchBin writeTextFile test_utils; };
+
+  suite = runCommand "mkTestDirectory" { } ''
+    mkdir -p $out/nix-watch-bats
+    cp -r ${help}       $out/nix-watch-bats/help.bats
+    cp -r ${shutdown}   $out/nix-watch-bats/shutdown.bats
+    cp -r ${postpone}   $out/nix-watch-bats/postpone.bats
+    cp -r ${no-restart} $out/nix-watch-bats/no-restart.bats
+    cp -r ${exec}       $out/nix-watch-bats/exec.bats
+    cp -r ${ignore}     $out/nix-watch-bats/ignore.bats
+    cp -r ${shell-args} $out/nix-watch-bats/shell-args.bats
+    cp -r ${workdir}    $out/nix-watch-bats/workdir.bats
+  '';
 in
 {
-  inherit test_utils;
-  help = callPackage ./help.nix { inherit bats nixWatchBin writeText; };
-  shutdown = callPackage ./shutdown.nix { inherit bats nixWatchBin writeText; };
-  postpone = callPackage ./postpone.nix { inherit bats nixWatchBin writeText; };
-  no-restart = callPackage ./no-restart.nix { inherit bats nixWatchBin writeText; };
-  exec = callPackage ./exec.nix { inherit bats nixWatchBin writeText test_utils; };
-  ignore = callPackage ./ignore.nix { inherit bats nixWatchBin writeText test_utils; };
-  shell-args = callPackage ./shell-args.nix { inherit bats nixWatchBin writeText test_utils; };
-  workdir = callPackage ./shell-args.nix { inherit bats nixWatchBin writeText test_utils; };
+  inherit
+    test_utils
+    help
+    shutdown
+    postpone
+    no-restart
+    exec
+    ignore
+    shell-args
+    workdir
+    suite
+    ;
 }
 

--- a/tests/exec.nix
+++ b/tests/exec.nix
@@ -1,20 +1,27 @@
-{ writeText, nixWatchBin, bats, test_utils }:
-writeText "exec.bats" ''
-  #!/usr/bin/env ${bats}/bin/bats
+{ writeTextFile, nixWatchBin, bats, test_utils }:
+let
+  name = "exec.bats";
+in
+writeTextFile {
+  inherit name;
+  text = ''
+    #!/usr/bin/env ${bats}/bin/bats
 
-  source ${test_utils}/bin/test_utils.sh
+    source ${test_utils}/bin/test_utils.sh
 
-  @test "nix-watch --exec runs custom command" {
-      run ${nixWatchBin}/bin/nix-watch --exec "nix build"
-      clean_output=$(remove_ansi_escape_chars "$output")
-      [[ "$clean_output" == *"nix build"* ]]
-      [ $? -eq 0 ]
-  }
+    @test "nix-watch --exec runs custom command" {
+        run ${nixWatchBin}/bin/nix-watch --exec "nix build"
+        clean_output=$(remove_ansi_escape_chars "$output")
+        [[ "$clean_output" == *"nix build"* ]]
+        [ $? -eq 0 ]
+    }
 
-  @test "nix-watch --exec prefixes nix when missing" {
-      run ${nixWatchBin}/bin/nix-watch --exec build
-      clean_output=$(remove_ansi_escape_chars "$output")
-      [[ "$clean_output" == *"nix build"* ]]
-      [ $? -eq 0 ]
-  }
-''
+    @test "nix-watch --exec prefixes nix when missing" {
+        run ${nixWatchBin}/bin/nix-watch --exec build
+        clean_output=$(remove_ansi_escape_chars "$output")
+        [[ "$clean_output" == *"nix build"* ]]
+        [ $? -eq 0 ]
+    }
+  '';
+  destination = "/nix-watch-bats/${name}";
+}

--- a/tests/exec.nix
+++ b/tests/exec.nix
@@ -23,5 +23,4 @@ writeTextFile {
         [ $? -eq 0 ]
     }
   '';
-  destination = "/nix-watch-bats/${name}";
 }

--- a/tests/help.nix
+++ b/tests/help.nix
@@ -1,10 +1,17 @@
-{ writeText, nixWatchBin, bats }:
-writeText "help.bats" ''
-  #!/usr/bin/env ${bats}/bin/bats
+{ writeTextFile, nixWatchBin, bats }:
+let
+  name = "help.bats";
+in
+writeTextFile {
+  inherit name;
+  text = ''
+    #!/usr/bin/env ${bats}/bin/bats
 
-  @test "nix-watch --help displays help message" {
-      run ${nixWatchBin}/bin/nix-watch --help
-      [ "$status" -eq 1 ]
-      [ "''${lines[0]}" = "USAGE:" ]
-  }
-''
+    @test "nix-watch --help displays help message" {
+        run ${nixWatchBin}/bin/nix-watch --help
+        [ "$status" -eq 1 ]
+        [ "''${lines[0]}" = "USAGE:" ]
+    }
+  '';
+  destination = "/nix-watch-bats/${name}";
+}

--- a/tests/help.nix
+++ b/tests/help.nix
@@ -13,5 +13,4 @@ writeTextFile {
         [ "''${lines[0]}" = "USAGE:" ]
     }
   '';
-  destination = "/nix-watch-bats/${name}";
 }

--- a/tests/ignore.nix
+++ b/tests/ignore.nix
@@ -23,5 +23,4 @@ writeTextFile {
         [ $? -eq 0 ]
     }
   '';
-  destination = "/nix-watch-bats/${name}";
 }

--- a/tests/ignore.nix
+++ b/tests/ignore.nix
@@ -1,20 +1,27 @@
-{ writeText, nixWatchBin, bats, test_utils }:
-writeText "ignore.bats" ''
-  #!/usr/bin/env ${bats}/bin/bats
+{ writeTextFile, nixWatchBin, bats, test_utils }:
+let
+  name = "ignore.bats";
+in
+writeTextFile {
+  inherit name;
+  text = ''
+    #!/usr/bin/env ${bats}/bin/bats
 
-  source ${test_utils}/bin/test_utils.sh
+    source ${test_utils}/bin/test_utils.sh
 
-  @test "nix-watch --ignore includes specified ignore patterns" {
-      run ${nixWatchBin}/bin/nix-watch --debug --ignore ".git" --ignore "node_modules"
-      clean_output=$(remove_ansi_escape_chars "$output")
-      [[ "$clean_output" == *"The following patterns will be ignored: [.git node_modules result* .*\.git]"* ]]
-      [ $? -eq 0 ]
-  }
+    @test "nix-watch --ignore includes specified ignore patterns" {
+        run ${nixWatchBin}/bin/nix-watch --debug --ignore ".git" --ignore "node_modules"
+        clean_output=$(remove_ansi_escape_chars "$output")
+        [[ "$clean_output" == *"The following patterns will be ignored: [.git node_modules result* .*\.git]"* ]]
+        [ $? -eq 0 ]
+    }
 
-  @test "nix-watch --ignore-nothing removes ignore patterns" {
-      run ${nixWatchBin}/bin/nix-watch --debug --ignore-nothing
-      clean_output=$(remove_ansi_escape_chars "$output")
-      [[ "$clean_output" == *"The following patterns will be ignored: []"* ]]
-      [ $? -eq 0 ]
-  }
-''
+    @test "nix-watch --ignore-nothing removes ignore patterns" {
+        run ${nixWatchBin}/bin/nix-watch --debug --ignore-nothing
+        clean_output=$(remove_ansi_escape_chars "$output")
+        [[ "$clean_output" == *"The following patterns will be ignored: []"* ]]
+        [ $? -eq 0 ]
+    }
+  '';
+  destination = "/nix-watch-bats/${name}";
+}

--- a/tests/no-restart.nix
+++ b/tests/no-restart.nix
@@ -20,5 +20,4 @@ writeTextFile {
         [ $? -eq 0 ]
     }
   '';
-  destination = "/nix-watch-bats/${name}";
 }

--- a/tests/no-restart.nix
+++ b/tests/no-restart.nix
@@ -1,17 +1,24 @@
-{ writeText, nixWatchBin, bats }:
-writeText "no-restart.bats" ''
-  #!/usr/bin/env ${bats}/bin/bats
+{ writeTextFile, nixWatchBin, bats }:
+let
+  name = "no-restart.bats";
+in
+writeTextFile {
+  inherit name;
+  text = ''
+    #!/usr/bin/env ${bats}/bin/bats
 
-  # TODO: This could be a more in depth check, but for now
-  # I've been unable to get the debug message to print. This
-  # is because of constraints of using bats to test restarts
-  # of a running process. If the initial process finishes
-  # before the changes that would trigger `no-restart` are
-  # detected, the debug message will not be present once
-  # the test finishes.
-  @test "nix-watch --no-restart does not restart on changes" {
-      run ${nixWatchBin}/bin/nix-watch --debug --no-restart
-      [[ "$output" == *"NO_RESTART=true"* ]]
-      [ $? -eq 0 ]
-  }
-''
+    # TODO: This could be a more in depth check, but for now
+    # I've been unable to get the debug message to print. This
+    # is because of constraints of using bats to test restarts
+    # of a running process. If the initial process finishes
+    # before the changes that would trigger `no-restart` are
+    # detected, the debug message will not be present once
+    # the test finishes.
+    @test "nix-watch --no-restart does not restart on changes" {
+        run ${nixWatchBin}/bin/nix-watch --debug --no-restart
+        [[ "$output" == *"NO_RESTART=true"* ]]
+        [ $? -eq 0 ]
+    }
+  '';
+  destination = "/nix-watch-bats/${name}";
+}

--- a/tests/postpone.nix
+++ b/tests/postpone.nix
@@ -1,10 +1,17 @@
-{ writeText, nixWatchBin, bats }:
-writeText "postpone.bats" ''
-  #!/usr/bin/env ${bats}/bin/bats
+{ writeTextFile, nixWatchBin, bats }:
+let
+  name = "postpone.bats";
+in
+writeTextFile {
+  inherit name;
+  text = ''
+    #!/usr/bin/env ${bats}/bin/bats
 
-  @test "nix-watch --postpone does not run command on start" {
-      run ${nixWatchBin}/bin/nix-watch --debug --postpone
-      [[ "$output" == *"Postpone flag was set, exiting without running command."* ]]
-      [ $? -eq 0 ]
-  }
-''
+    @test "nix-watch --postpone does not run command on start" {
+        run ${nixWatchBin}/bin/nix-watch --debug --postpone
+        [[ "$output" == *"Postpone flag was set, exiting without running command."* ]]
+        [ $? -eq 0 ]
+    }
+  '';
+  destination = "/nix-watch-bats/${name}";
+}

--- a/tests/postpone.nix
+++ b/tests/postpone.nix
@@ -13,5 +13,4 @@ writeTextFile {
         [ $? -eq 0 ]
     }
   '';
-  destination = "/nix-watch-bats/${name}";
 }

--- a/tests/shell-args.nix
+++ b/tests/shell-args.nix
@@ -1,21 +1,28 @@
-{ writeText, nixWatchBin, bats, test_utils }:
-writeText "shell-args.bats" ''
-  #!/usr/bin/env ${bats}/bin/bats
-
-  source ${test_utils}/bin/test_utils.sh
-
-  @test "nix-watch -s appends shell args executed after nix command" {
-      run ${nixWatchBin}/bin/nix-watch --debug -s echo "Success"
-      echo "$output"
-      clean_output=$(remove_ansi_escape_chars "$output")
-      [[ "$clean_output" == *"The following arguments will be passed to shell: [echo Success]"* ]]
-      [ $? -eq 0 ]
-  }
-
-  @test "nix-watch -- appends shell args executed after nix command" {
-      run ${nixWatchBin}/bin/nix-watch --debug -- echo "Success"
-      clean_output=$(remove_ansi_escape_chars "$output")
-      [[ "$clean_output" == *"The following arguments will be passed to shell: [echo Success]"* ]]
-      [ $? -eq 0 ]
-  }
-''
+{ writeTextFile, nixWatchBin, bats, test_utils }:
+let
+  name = "shell-args.bats";
+in
+writeTextFile {
+  inherit name;
+  text = ''
+    #!/usr/bin/env ${bats}/bin/bats
+  
+    source ${test_utils}/bin/test_utils.sh
+  
+    @test "nix-watch -s appends shell args executed after nix command" {
+        run ${nixWatchBin}/bin/nix-watch --debug -s echo "Success"
+        echo "$output"
+        clean_output=$(remove_ansi_escape_chars "$output")
+        [[ "$clean_output" == *"The following arguments will be passed to shell: [echo Success]"* ]]
+        [ $? -eq 0 ]
+    }
+  
+    @test "nix-watch -- appends shell args executed after nix command" {
+        run ${nixWatchBin}/bin/nix-watch --debug -- echo "Success"
+        clean_output=$(remove_ansi_escape_chars "$output")
+        [[ "$clean_output" == *"The following arguments will be passed to shell: [echo Success]"* ]]
+        [ $? -eq 0 ]
+    }
+  '';
+  destination = "/nix-watch-bats/${name}";
+}

--- a/tests/shell-args.nix
+++ b/tests/shell-args.nix
@@ -24,5 +24,4 @@ writeTextFile {
         [ $? -eq 0 ]
     }
   '';
-  destination = "/nix-watch-bats/${name}";
 }

--- a/tests/shutdown.nix
+++ b/tests/shutdown.nix
@@ -1,10 +1,17 @@
-{ writeText, nixWatchBin, bats }:
-writeText "shutdown.bats" ''
-  #!/usr/bin/env ${bats}/bin/bats
-
-  @test "nix-watch handles shutdown gracefully" {
-      run ${nixWatchBin}/bin/nix-watch --debug
-      [[ "$output" == *"Received termination signal, cleaning up"* ]]
-      [ $? -eq 0 ]
-  }
-''
+{ writeTextFile, nixWatchBin, bats }:
+let
+  name = "shutdown.bats";
+in
+writeTextFile {
+  inherit name;
+  text = ''
+    #!/usr/bin/env ${bats}/bin/bats
+  
+    @test "nix-watch handles shutdown gracefully" {
+        run ${nixWatchBin}/bin/nix-watch --debug
+        [[ "$output" == *"Received termination signal, cleaning up"* ]]
+        [ $? -eq 0 ]
+    }
+  '';
+  destination = "/nix-watch-bats/${name}";
+}

--- a/tests/shutdown.nix
+++ b/tests/shutdown.nix
@@ -13,5 +13,4 @@ writeTextFile {
         [ $? -eq 0 ]
     }
   '';
-  destination = "/nix-watch-bats/${name}";
 }

--- a/tests/workdir.nix
+++ b/tests/workdir.nix
@@ -1,14 +1,21 @@
-{ writeText, nixWatchBin, bats, test_utils }:
-writeText "workdir.bats" ''
-  #!/usr/bin/env ${bats}/bin/bats
-
-  source ${test_utils}/bin/test_utils.sh
-
-  @test "nix-watch --workdir changes the watch directory" {
-      run ${nixWatchBin}/bin/nix-watch --debug -C $(pwd)/tests
-      echo "$output"
-      clean_output=$(remove_ansi_escape_chars "$output")
-      [[ "$clean_output" == *"nix-watch/tests"* ]]
-      [ $? -eq 0 ]
-  }
-''
+{ writeTextFile, nixWatchBin, bats, test_utils }:
+let
+  name = "workdir.bats";
+in
+writeTextFile {
+  inherit name;
+  text = ''
+    #!/usr/bin/env ${bats}/bin/bats
+  
+    source ${test_utils}/bin/test_utils.sh
+  
+    @test "nix-watch --workdir changes the watch directory" {
+        run ${nixWatchBin}/bin/nix-watch --debug -C $(pwd)/tests
+        echo "$output"
+        clean_output=$(remove_ansi_escape_chars "$output")
+        [[ "$clean_output" == *"nix-watch/tests"* ]]
+        [ $? -eq 0 ]
+    }
+  '';
+  destination = "/nix-watch-bats/${name}";
+}

--- a/tests/workdir.nix
+++ b/tests/workdir.nix
@@ -17,5 +17,4 @@ writeTextFile {
         [ $? -eq 0 ]
     }
   '';
-  destination = "/nix-watch-bats/${name}";
 }


### PR DESCRIPTION
Closes #29 

Groups together bats tests into a nix store directory, and passes that directory to bats in `checks.nix-watch-bats`. Refactors `writeText`s into `writeTextFile`s for better syntax highlighting from `nil` lsp.